### PR TITLE
UML Diagram GitHub Workflow

### DIFF
--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -1,0 +1,37 @@
+name: Generate PlantUML Diagrams
+on:
+  push:
+    paths:
+      - 'docs/diagrams/**.puml'
+      - '!docs/diagrams/tracing/**.puml'
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      UML_FILES: ".puml"
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed UML files
+        id: getfile
+        run: |
+          echo "::set-output name=files::$(git diff-tree -r --no-commit-id --name-only ${{ github.sha }} | grep ${{ env.UML_FILES }} | xargs)"
+
+      - name: UML files considered echo output
+        run: |
+          echo ${{ steps.getfile.outputs.files }}
+
+      - name: Generate PNG Diagrams
+        if: contains(steps.getfile.outputs.files, 'puml')
+        uses: cloudbees/plantuml-github-action@master
+        with:
+          args: -v -tpng ${{ steps.getfile.outputs.files }} -o "/github/workspace/docs/images"
+
+      - name: Push Local Changes
+        if: contains(steps.getfile.outputs.files, 'puml')
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: "Generate PNG images for PlantUML diagrams"


### PR DESCRIPTION
* Add workflow to automatically generate and commit PlantUML pngs when .puml files are updated, so as to eliminate the manual labor of exporting each .puml file as an image whenever they are changed.
* Updated png files will be reflected as a github push in the same commit branch.

Credits for workflow to: [qwoprocks](https://github.com/qwoprocks)

---
Library used: [PlantUML GitHub Action](https://github.com/cloudbees/plantuml-github-action)
Request: [issue](https://github.com/nus-cs2103-AY2021S1/forum/issues/309#issue-718884781)